### PR TITLE
Darwin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A fast CLI documentation searcher for Nix.
 - Nixpkgs Comments
 - Nixpkgs Tree (pkgs., pkgs.lib.)
 - NixOS Options
+- Nix-Darwin Options
 - Home-Manager Options
 
 ## Usage

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1599050737,
-        "narHash": "sha256-jxUhBQ49DYMnL17SrPNGTEp+Wb5Pj89CxW8OLwnXl1g=",
+        "lastModified": 1627480871,
+        "narHash": "sha256-6h8HZyfXFQB8LYDwQU5SEcabM2whu47COSUcOf5O1dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18348c7829ae93ebe436497ca7ad96cdb8d39935",
+        "rev": "65584b6a0bbc82df63789b48570bb9e84d58dd29",
         "type": "github"
       },
       "original": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "529e910a3f423a8211f8739290014b754b2555b6",
-        "sha256": "0bcy9nmyaan5jvp0wg80wkizc9j166ns685rdr1kbhkvdpywv46y",
+        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "sha256": "0k1pk2ixnxl6njjrgy750gm6m1nkkdsah383n3wp4ybrzacnav5h",
         "type": "tarball",
-        "url": "https://github.com/nmattia/naersk/archive/529e910a3f423a8211f8739290014b754b2555b6.tar.gz",
+        "url": "https://github.com/nmattia/naersk/archive/e09c320446c5c2516d430803f7b19f5833781337.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "e82eb322ea32a747a51c431d7787221bcc6d9038",
-        "sha256": "1fy4dcr05d80diwlxmh42xnjm5ki1pkbky38smvlqjaky2y2f71f",
+        "rev": "e0ca65c81a2d7a4d82a189f1e23a48d59ad42070",
+        "sha256": "1pq9nh1d8nn3xvbdny8fafzw87mj7gsmp6pxkdl65w2g18rmcmzx",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/e82eb322ea32a747a51c431d7787221bcc6d9038.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/e0ca65c81a2d7a4d82a189f1e23a48d59ad42070.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "289466dd6a11c65a7de4a954d6ebf66c1ad07652",
-        "sha256": "0r5ja052s86fr54fm1zlhld3fwawz2w1d1gd6vbvpjrpjfyajibn",
+        "rev": "75f4ba05c63be3f147bcc2f7bd4ba1f029cedcb1",
+        "sha256": "157c64220lf825ll4c0cxsdwg7cxqdx4z559fdp7kpz0g6p8fhhr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/289466dd6a11c65a7de4a954d6ebf66c1ad07652.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/75f4ba05c63be3f147bcc2f7bd4ba1f029cedcb1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ impl DocEntry {
     pub fn source(&self) -> &str {
         match self {
             DocEntry::OptionDoc(typ, _) => match typ {
+                OptionsDatabaseType::NixDarwin => "NixDarwin Options",
                 OptionsDatabaseType::NixOS => "NixOS Options",
                 OptionsDatabaseType::HomeManager => "HomeManager Options",
             },

--- a/src/nix/darwin-options.nix
+++ b/src/nix/darwin-options.nix
@@ -1,0 +1,13 @@
+let
+  inherit (import <nixpkgs> {}) runCommandLocal;
+
+  nix-darwin = let
+    inherit (builtins.tryEval <darwin>) success value;
+  in if success then value else fetchTarball https://github.com/LnL7/nix-darwin/archive/refs/heads/master.tar.gz;
+
+  eval = import nix-darwin { configuration = ({ ... }: { }); };
+  opts = eval.config.system.build.manual.optionsJSON;
+in
+runCommandLocal "options.json" { inherit opts; } ''
+  cp $opts/share/doc/darwin/options.json $out
+''

--- a/src/nix/nixos-options.nix
+++ b/src/nix/nixos-options.nix
@@ -1,0 +1,10 @@
+with import <nixpkgs> {}; let
+  eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
+      system = "x86_64-linux";
+      modules = [ ];
+  };
+  opts = (nixosOptionsDoc { options = eval.options; }).optionsJSON;
+in
+runCommandLocal "options.json" { inherit opts; } ''
+  cp $opts/share/doc/nixos/options.json $out
+''

--- a/src/options_docsource.rs
+++ b/src/options_docsource.rs
@@ -124,7 +124,7 @@ pub fn get_nixos_json_doc_path() -> Result<PathBuf, std::io::Error> {
         .env("NIXPKGS_ALLOW_INSECURE", "1")
         .arg("--no-out-link")
         .arg("-E")
-        .arg(r#"with import <nixpkgs> {}; let eval = import (pkgs.path + "/nixos/lib/eval-config.nix") { modules = []; }; opts = (nixosOptionsDoc { options = eval.options; }).optionsJSON; in runCommandLocal "options.json" { inherit opts; } "cp $opts/share/doc/nixos/options.json $out""#)
+        .arg(include_str!("nix/nixos-options.nix"))
         .output()
         .map(|o| String::from_utf8(o.stdout).unwrap())?;
 


### PR DESCRIPTION
- Fixes a problem building a NixOS options file on Darwin
- Bumps `nixpkgs` as it is required for builds to work on current versions of macOS.
- Bumps `naersk` so that it works with current `nixpkgs`
- Adds support for nix-darwin options

I tested getting NixOS options from Darwin and getting nix-darwin options from NixOS and it seems to be working ok.

#### PS
As a semi-related aside, I also rebased the @elkowar [fork](https://github.com/elkowar/rnix-lsp) on [upstream](https://github.com/nix-community/rnix-lsp) to make it work with this (due to required newer versions as mentioned above). It took some conflict resolution but nothing too bad and it seems to work ok (see [here](https://github.com/kreisys/rnix-lsp)).

Any reason not to upstream that?
It looks like an obvious improvement over not having those features...